### PR TITLE
Improve handling of initData for DataModels

### DIFF
--- a/packages/model.mixins.cache.memory/index.ts
+++ b/packages/model.mixins.cache.memory/index.ts
@@ -31,11 +31,11 @@ export function InMemoryCacheMixin() {
       return super.delete()
     }
 
-    protected fetch() {
+    protected fetch(...args: any[]) {
       this[IS_CACHED] = true
       const key = hashParams(ko.toJS(this.params))
       if (!CACHE[CACHE_ID][key]) {
-        CACHE[CACHE_ID][key] = super.fetch()
+        CACHE[CACHE_ID][key] = super.fetch(...args)
       }
       return CACHE[CACHE_ID][key]
     }

--- a/packages/model.mixins.lazy/index.ts
+++ b/packages/model.mixins.lazy/index.ts
@@ -12,24 +12,28 @@ export function LazyMixin(triggerProp: string) {
     constructor(...args: any[]) {
       super(...args)
 
-      let awake = false
-      let v = (this as any)[triggerProp]
-      Object.defineProperty(this, triggerProp, {
-        get: () => {
-          if (!awake) {
-            awake = true
-            this.fetch = this[ORIGINAL_FETCH]
-            this.update().catch(() => { /* @TODO */  })
-          }
-          return v
-        },
-        set: (_v) => v = _v
-      })
+      if (args[1]) {
+        this.fetch = this[ORIGINAL_FETCH]
+      } else {
+        let awake = false
+        let v = (this as any)[triggerProp]
+        Object.defineProperty(this, triggerProp, {
+          get: () => {
+            if (!awake) {
+              awake = true
+              this.fetch = this[ORIGINAL_FETCH]
+              this.update().catch(() => { /* @TODO */  })
+            }
+            return v
+          },
+          set: (_v) => v = _v
+        })
+      }
     }
 
-    protected async fetch() {
+    protected async fetch(initData: any = {}) {
       this[ORIGINAL_FETCH] = super.fetch.bind(this)
-      return {}
+      return initData
     }
   }
 }

--- a/packages/model.mixins.pager/index.ts
+++ b/packages/model.mixins.pager/index.ts
@@ -2,6 +2,7 @@ import 'core-js/es7/symbol'
 
 import * as ko from 'knockout'
 import { DataModelConstructorBuilder } from '@profiscience/knockout-contrib-model-builders-data'
+import { INITIALIZED } from '@profiscience/knockout-contrib-router-plugins-init'
 
 export type PaginationStrategy<T extends { [k: string]: any }> = (page: number) => T
 
@@ -28,7 +29,13 @@ export function PagerMixin<PaginationParams = { page: number }>(
       Object.assign(args[0], strategy(1))
       super(...args)
 
+      this.pager = this.createPager()
       this.hasMore = ko.observable(true)
+
+      const initialized = this[INITIALIZED]
+      this[INITIALIZED] = initialized
+        // @TODO unchain this when proper error handling is implemented
+        .then(() => this.pager.next().then(() => { /* void */ }))
     }
 
     public async getMore(): Promise<boolean> {

--- a/packages/model.mixins.rest/mixin.ts
+++ b/packages/model.mixins.rest/mixin.ts
@@ -18,8 +18,8 @@ export const createRESTMixin = (config: RestMixinConfig = {}) => (controller: st
   return <P, T extends { new(...args: any[]): DataModelConstructorBuilder<P> }>(ctor: T) => class extends ctor {
     protected api = api
 
-    protected fetch() {
-      return api.get({ params: this.params })
+    protected async fetch(initData?: any) {
+      return initData || await api.get({ params: this.params })
     }
 
     public async create() {

--- a/packages/model.mixins.spread/index.ts
+++ b/packages/model.mixins.spread/index.ts
@@ -18,30 +18,17 @@ export function SpreadMixin(property: string) {
     P, T extends { new(...args: any[]): DataModelConstructorBuilder<P> }
   >(ctor: T) => {
     return class extends ctor {
-      protected [SPREAD_MAPPINGS]: { [k: string]: string[] }
+      protected [SPREAD_MAPPINGS]: { [k: string]: string[] } = {}
 
-      constructor(...args: any[]) {
-        let spreadKeys: string[] = []
-
-        if (args[1]) spreadKeys = spread(args[1], property)
-
-        super(...args)
-
-        if (!this[SPREAD_MAPPINGS]) this[SPREAD_MAPPINGS] = {}
-        this[SPREAD_MAPPINGS][property] = spreadKeys
-      }
-
-      protected async fetch() {
-        const res = await super.fetch()
+      protected async fetch(...args: any[]) {
+        const res = await super.fetch(...args)
         if (Array.isArray(res[property])) {
           throw new Error(
             // tslint:disable-next-line max-line-length
             '[@profiscience/knockout-contrib-model-mixins-spread] Can not spread an array onto a model (i.e. Object.assign({}, []))'
           )
         }
-
         this[SPREAD_MAPPINGS][property] = spread(res, property)
-
         return res
       }
 

--- a/packages/model.mixins.spread/test.ts
+++ b/packages/model.mixins.spread/test.ts
@@ -118,7 +118,7 @@ describe('model.mixins.spread', () => {
       public foo: KnockoutObservable<string>
     }
 
-    const model = new DataModel({}, {
+    const model = await DataModel.create({}, {
       foos: {
         foo: 'foo'
       },

--- a/packages/model.mixins.transform/index.ts
+++ b/packages/model.mixins.transform/index.ts
@@ -3,14 +3,8 @@ import { DataModelConstructorBuilder } from '@profiscience/knockout-contrib-mode
 
 export function TransformMixin<P extends {}>(transform: (fetchData: any, params: P) => any) {
   return <T extends { new(...args: any[]): DataModelConstructorBuilder<P> }>(ctor: T) => class extends ctor {
-
-    constructor(...args: any[]) {
-      if (args[1]) args[1] = transform(args[1], args[0])
-      super(...args)
-    }
-
-    protected async fetch() {
-      return transform(await super.fetch(), this.params)
+    protected async fetch(...args: any[]) {
+      return transform(await super.fetch(...args), this.params)
     }
   }
 }

--- a/packages/model.mixins.transform/test.ts
+++ b/packages/model.mixins.transform/test.ts
@@ -52,7 +52,7 @@ describe('model.mixins.transform', () => {
       public foos: KnockoutObservableArray<string>
     }
 
-    const model = new DataModel({}, { foos: FOOS })
+    const model = await DataModel.create({}, { foos: FOOS })
 
     expect(ko.toJS(model.foos())).toEqual(reverse(FOOS))
 


### PR DESCRIPTION
The current implementation of `initData` handling for DataModels, that is instantiating a DataModel providing it's data rather than using `.fetch()` for initialization, requires mixins to implement both APIs, and leads to inconsistencies in execution order in practice.

This PR changes the interface of the `fetch` method to accept the initial data as its first argument (if supplied, and this is the initialization and not an update), so that it can be passed through, and mixins that augment fetch (e.g. `TransformMixin`) are still applied, without having to explicitly handle the case of initial data.

What this means however, that any mixin that supplies data, rather than changes it (e.g. `RestMixin`), should handle the case of initial data by returning it if supplied.