### PR TITLE
Fix componentInitializerPlugin

### DIFF
--- a/packages/router.plugins.init/index.ts
+++ b/packages/router.plugins.init/index.ts
@@ -14,28 +14,26 @@ export function componentInitializerRoutePlugin(
   if (!routeConfig.component) return
 
   return (ctx: Context & IContext) => {
-    if (!(ctx.component as IRoutedComponentInstance).viewModel) return
-
     ctx.queue(
       (async () => {
         const { viewModel } = await (ctx.component as Promise<
           IRoutedComponentInstance
         >)
 
-        if (viewModel) {
-          const initializers = Object.keys(viewModel)
-            .filter((prop: any) => {
-              const v = (viewModel as any)[prop]
-              return typeof v === 'undefined' || v === null
-                ? false
-                : v[INITIALIZED]
-            })
-            .map((prop: any) => (viewModel as any)[prop][INITIALIZED])
+        if (!viewModel) return
 
-          if (viewModel[INITIALIZED]) initializers.push(viewModel[INITIALIZED])
+        const initializers = Object.keys(viewModel)
+          .filter((prop: any) => {
+            const v = (viewModel as any)[prop]
+            return typeof v === 'undefined' || v === null
+              ? false
+              : v[INITIALIZED]
+          })
+          .map((prop: any) => (viewModel as any)[prop][INITIALIZED])
 
-          await Promise.all(initializers)
-        }
+        if (viewModel[INITIALIZED]) initializers.push(viewModel[INITIALIZED])
+
+        await Promise.all(initializers)
       })()
     )
   }

--- a/packages/router.plugins.init/test.ts
+++ b/packages/router.plugins.init/test.ts
@@ -17,7 +17,7 @@ Route.usePlugin(componentRoutePlugin)
 describe('router.plugins.init', () => {
   test('works with router.plugins.component, initializes props with INITIALIZED key on ViewModel', async () => {
     const spy = jest.spyOn(Promise, 'all')
-    const promise = Promise.resolve()
+    const promise = Symbol()
 
     const getComponent = () => ({
       template: Promise.resolve({ default: 'Hello, World!' }),
@@ -48,7 +48,7 @@ describe('router.plugins.init', () => {
 
   test('works with router.plugins.component, initializes INITIALIZED key on ViewModel', async () => {
     const spy = jest.spyOn(Promise, 'all')
-    const promise = Promise.resolve()
+    const promise = Symbol()
 
     const getComponent = () => ({
       template: Promise.resolve({ default: 'Hello, World!' }),
@@ -102,6 +102,10 @@ describe('router.plugins.init', () => {
         if (lifecycle && lifecycle.beforeRender) lifecycle.beforeRender()
       }
     }).not.toThrow()
+
+    await expect(
+      Promise.all(queue.mock.calls.map(([p]) => p))
+    ).resolves.toBeTruthy()
   })
 
   test("doesn'nt blow up with defined properties w/ undefined values (see comment in test file)", async () => {

--- a/packages/router/src/context.ts
+++ b/packages/router/src/context.ts
@@ -227,7 +227,7 @@ export class Context /* implements IContext, use Context & IContext */ {
 
       if (ret) {
         // iterable (generator)
-        if (typeof (ret as IterableIterator<any>).next === 'function') {
+        if (typeof (ret as any).next === 'function') {
           // tslint:disable-line:strict-type-predicates
           const iterator = ret as IterableIterator<any>
           lifecycle = {


### PR DESCRIPTION
In attempting to add an early bail, I neglected the fact that `ctx.component` begins as a promise, and the test passed as a false positive.