### PR TITLE
Add QueryMixin for DataModelConstructorBulider

### DIFF
--- a/packages/_/index.ts
+++ b/packages/_/index.ts
@@ -13,6 +13,7 @@ export * from '@profiscience/knockout-contrib-model-builders-data'
 export * from '@profiscience/knockout-contrib-model-builders-view'
 
 export * from '@profiscience/knockout-contrib-model-mixins-pager'
+export * from '@profiscience/knockout-contrib-model-mixins-query'
 export * from '@profiscience/knockout-contrib-model-mixins-transform'
 
 export * from '@profiscience/knockout-contrib-query'

--- a/packages/_/package.json
+++ b/packages/_/package.json
@@ -40,6 +40,7 @@
     "@profiscience/knockout-contrib-model-builders-data": "^2.0.0-rc.1",
     "@profiscience/knockout-contrib-model-builders-view": "^2.0.0-rc.1",
     "@profiscience/knockout-contrib-model-mixins-pager": "^2.0.0-rc.1",
+    "@profiscience/knockout-contrib-model-mixins-query": "0.0.0",
     "@profiscience/knockout-contrib-model-mixins-transform": "^2.0.0-rc.1",
     "@profiscience/knockout-contrib-query": "^2.0.0-rc.1",
     "@profiscience/knockout-contrib-router": "^2.0.0-rc.2",

--- a/packages/model.mixins.query/README.md
+++ b/packages/model.mixins.query/README.md
@@ -1,0 +1,36 @@
+# model.mixins.query
+
+> This package is intended to be consumed via the [@profiscience/knockout-contrib](../_) metapackage
+
+Adds a `.query` property using the [query](../query) package for persistent, stateless data model params.
+
+In other words, initializes data model params via the querystring, and mirrors changes so that the same query will be applied if the page is reloaded. Useful for making bookmark-able pages.
+
+See the [query](../query) package for more details.
+
+## Usage
+
+```typescript
+import {
+  DataModelConstructorBuilder,
+  QueryMixin
+} from '@profiscience/knockout-contrib'
+
+class MyDataModel extends DataModelConstructorBuilder.Mixin(
+  QueryMixin(
+    { someQuerystringParameter: '' } /* Query options (see query package) */
+  )
+)<any> {}
+
+const model = new MyDataModel()
+
+// if querystring contains `?someQuerystringParameter=foo`
+model.query.someQuerystringParameter() === 'foo'
+
+// update querystring to `?someQuerystringParameter=bar`
+model.query.someQuerystringParameter('bar')
+
+// query params are mirrored on `.params`, so it plays well will mixins
+// that follow the correct conventions w/o additional buy in
+model.params.someQuerystringParameter()
+```

--- a/packages/model.mixins.query/index.ts
+++ b/packages/model.mixins.query/index.ts
@@ -1,0 +1,26 @@
+import { DataModelConstructorBuilder } from '@profiscience/knockout-contrib-model-builders-data'
+import {
+  Query,
+  IQuery,
+  IQueryConfig
+} from '@profiscience/knockout-contrib-query'
+
+export function QueryMixin<Q extends IQueryConfig>(opts: Q) {
+  return <
+    P extends IQuery<Q>,
+    T extends { new (...args: any[]): DataModelConstructorBuilder<P> }
+  >(
+    ctor: T
+  ) =>
+    class extends ctor {
+      public query: Query & IQuery<Q>
+
+      constructor(...args: any[]) {
+        const query = Query.create<Q>(opts)
+        Object.assign(args[0], query)
+        super(...args)
+
+        this.query = query
+      }
+    }
+}

--- a/packages/model.mixins.query/package.json
+++ b/packages/model.mixins.query/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@profiscience/knockout-contrib-model-mixins-query",
+  "version": "0.0.0",
+  "license": "WTFPL",
+  "author": "Casey Webb (https://caseyWebb.xyz)",
+  "homepage": "https://github.com/Profiscience/knockout-contrib/tree/master/packages/model.mixins.query",
+  "bugs": "https://github.com/Profiscience/knockout-contrib/issues",
+  "repository": "github:Profiscience/knockout-contrib",
+  "main": "dist/node/index.js",
+  "module": "dist/default/index.js",
+  "types": "index.ts",
+  "peerDependencies": {
+    "@profiscience/knockout-contrib-model-builders-data": ">=2.0.0-rc.0",
+    "@profiscience/knockout-contrib-query": ">=2.0.0-rc.0",
+    "knockout": "3.5.0-rc"
+  },
+  "dependencies": {
+    "core-js": "^2.5.3",
+    "tslib": "^1.8.0"
+  },
+  "devDependencies": {
+    "@profiscience/knockout-contrib-model-builders-data": "^2.0.0-rc.1",
+    "@profiscience/knockout-contrib-query": ">=2.0.0-rc.1"
+  }
+}

--- a/packages/model.mixins.query/test.ts
+++ b/packages/model.mixins.query/test.ts
@@ -1,0 +1,92 @@
+// tslint:disable:max-classes-per-file
+
+import * as ko from 'knockout'
+import { DataModelConstructorBuilder } from '@profiscience/knockout-contrib-model-builders-data'
+import { Query } from '@profiscience/knockout-contrib-query'
+import '@profiscience/knockout-contrib-jest-matchers'
+
+import { QueryMixin } from './index'
+
+describe('model.mixins.query', () => {
+  test('creates and attaches a query object to the model', async () => {
+    class DataModel<P> extends DataModelConstructorBuilder.Mixin(
+      QueryMixin({ myQueryParam: '' })
+    )<P> {
+      protected async fetch(): Promise<any> {
+        return {
+          foos: ['foo', 'bar', 'baz', 'qux']
+        }
+      }
+    }
+
+    const model = await DataModel.create({})
+
+    expect(model.query).toBeInstanceOf(Query)
+    expect(model.query.myQueryParam).toBeObservable()
+
+    model.dispose()
+  })
+
+  test('merges query with params', async () => {
+    class DataModel<P> extends DataModelConstructorBuilder.Mixin(
+      QueryMixin({ searchText: '' })
+    )<P> {
+      protected async fetch(): Promise<any> {
+        expect(this.params.searchText).toBeObservable()
+        expect(this.params.searchText()).toBe('')
+        return []
+      }
+    }
+
+    const model = await DataModel.create({})
+
+    model.dispose()
+  })
+
+  test('modifying query parameter triggers update', async () => {
+    const fetch = jest.fn()
+
+    class DataModel<P> extends DataModelConstructorBuilder.Mixin(
+      QueryMixin({ myQueryParam: '' })
+    )<P> {
+      protected async fetch() {
+        fetch()
+        return ''
+      }
+    }
+
+    const model = await DataModel.create({})
+
+    model.query.myQueryParam('foo')
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  test('query is disposed when model is disposed', async () => {
+    /**
+     * This happens automatically thanks to the disposalAggregator mixin included
+     * in both of the model builders, but it's still good to test to make sure that
+     * it's really happening.
+     */
+    const fetch = jest.fn()
+
+    class DataModel<P> extends DataModelConstructorBuilder.Mixin(
+      QueryMixin({ myQueryParam: '' })
+    )<P> {
+      constructor(params: P, initData?: any) {
+        super(params, initData)
+      }
+      protected async fetch() {
+        fetch()
+        return ''
+      }
+    }
+
+    const model = await DataModel.create({})
+
+    model.query.dispose = jest.fn()
+    model.dispose()
+
+    expect(model.query.dispose).toHaveBeenCalled()
+  })
+})

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -8,7 +8,7 @@
 
 > This package is intended for consumption via the [@profiscience/knockout-contrib](../_) metapackage
 
-Easy-peasy Querystrings for Knockout
+Persistent, stateless read/write querystring abstraction for KnockoutJS.
 
 ## Basic Usage
 

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -1,4 +1,4 @@
-# querystring
+# query
 
 [![Version][npm-version-shield]][npm]
 [![Dependency Status][david-dm-shield]][david-dm]
@@ -6,22 +6,9 @@
 [![Dev Dependency Status][david-dm-dev-shield]][david-dm-dev]
 [![Downloads][npm-stats-shield]][npm-stats]
 
+> This package is intended for consumption via the [@profiscience/knockout-contrib](../_) metapackage
+
 Easy-peasy Querystrings for Knockout
-
-## Installation
-
-```bash
-$ yarn add @profiscience/knockout-contrib-querystring
-```
-
-_or_
-
-```bash
-$ npm install @profiscience/knockout-contrib-querystring
-```
-
-Typing are included, but have the caveat that query params that are **observable arrays**
-will only be typed as **observables**. This is due to a limitation with mapped types in TypeScript.
 
 ## Basic Usage
 

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.1",
   "license": "WTFPL",
   "author": "Casey Webb (https://caseyWebb.xyz)",
-  "homepage": "https://github.com/Profiscience/knockout-contrib/tree/master/packages/querystring",
+  "homepage": "https://github.com/Profiscience/knockout-contrib/tree/master/packages/query",
   "bugs": "https://github.com/Profiscience/knockout-contrib/issues",
   "repository": "github:Profiscience/knockout-contrib",
   "main": "dist/node/index.js",

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -45,10 +45,13 @@ export class Query {
         : encodeURIComponent(JSON.stringify(obj))
   }
 
-  private readonly _group?: string
+  private readonly _group!: string
 
   constructor(config: IQueryConfig, group?: string) {
-    this._group = group as string
+    Object.defineProperty(this, '_group', {
+      enumerable: false,
+      get: () => group
+    })
 
     if (isUndefined(Query._raw[this._group])) {
       Query._raw[this._group] = {}

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -18,7 +18,7 @@ export type IQueryParam<T> = ko.Computed<T | undefined> & {
   set(v: T | IQueryParamConfig<any>): void
 }
 
-type IQuery<T> = { [P in keyof T]: IQueryParam<T[P]> }
+export type IQuery<T> = { [P in keyof T]: IQueryParam<T[P]> }
 
 export interface IQueryParamConfig<T extends MaybeArray<Primitive>> {
   default: T

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -10,6 +10,8 @@ import {
   omit
 } from './utils'
 
+const VIA_FACTORY = Symbol('VIA_FACTORY')
+
 export type IQueryParam<T> = ko.Computed<T | undefined> & {
   isDefault(): boolean
   clear(): void
@@ -47,7 +49,14 @@ export class Query {
 
   private readonly _group!: string
 
-  constructor(config: IQueryConfig, group?: string) {
+  constructor(config: IQueryConfig, group?: string, isViaFactory?: symbol) {
+    if (isViaFactory !== VIA_FACTORY) {
+      // tslint:disable-next-line:no-console
+      console.warn(
+        '[@profiscience/knockout-contrib] Use the Query.create() factory function instead of `new`'
+      )
+    }
+
     Object.defineProperty(this, '_group', {
       enumerable: false,
       get: () => group
@@ -132,7 +141,10 @@ export class Query {
     config: T,
     group?: string
   ): IQuery<T> & Query {
-    return new Query(config, group) as any
+    // use an internal symbol to ensure that the factory function is used
+    // (and can't be faked). If the constructo is used directly, type-checking
+    // will suffer.
+    return new Query(config, group, VIA_FACTORY) as any
   }
 
   public static setParser(parser: IQueryParser) {

--- a/packages/query/test.ts
+++ b/packages/query/test.ts
@@ -398,4 +398,14 @@ describe('querystring', () => {
 
     expect(Query.fromQS()).toEqual({ foo: 'foo' })
   })
+
+  test('logs a warning if the constructor is used directly', () => {
+    console.warn = jest.fn()
+
+    const query = new Query({ foo: 'foo' })
+
+    expect(console.warn).toHaveBeenLastCalledWith(
+      '[@profiscience/knockout-contrib] Use the Query.create() factory function instead of `new`'
+    )
+  })
 })


### PR DESCRIPTION
Creates a query instance for a data model, allowing persistent (bookmarkable) params _outside_ of routing (i.e. not using route params).