### PR TITLE
feat(query): Add "sticky" param option

### DIFF
--- a/packages/query/test.ts
+++ b/packages/query/test.ts
@@ -120,6 +120,39 @@ describe('querystring', () => {
     query.dispose()
   })
 
+  test('sticky', () => {
+    const createQuery = () =>
+      Query.create({
+        stickyParam: {
+          default: 'foo',
+          sticky: true
+        },
+        notStickyParam: {
+          default: 'foo',
+          sticky: false
+        }
+      })
+
+    let query = createQuery()
+
+    query.stickyParam('bar')
+    query.notStickyParam('bar')
+
+    query.dispose()
+
+    query.stickyParam('baz') // stop tracking after dispose
+
+    history.replaceState(null, '', location.pathname)
+
+    query = createQuery()
+
+    expect(query.stickyParam()).toBe('bar')
+    // sanity check
+    expect(query.notStickyParam()).toBe('foo')
+
+    query.dispose()
+  })
+
   test('advanced', () => {
     history.replaceState(null, '', location.pathname + '?{"foo": "notfoo"}')
 


### PR DESCRIPTION
Make query param persistent across browser reloads by storing values in localStorage and using them
as the `init` config option to restore.