### PR TITLE
feat(router.plugins.init): add init method support

### DIFF
--- a/packages/router.plugins.init/index.ts
+++ b/packages/router.plugins.init/index.ts
@@ -34,6 +34,10 @@ export function componentInitializerRoutePlugin(
         if (viewModel[INITIALIZED]) initializers.push(viewModel[INITIALIZED])
 
         await Promise.all(initializers)
+
+        if (viewModel.init) {
+          await viewModel.init()
+        }
       })()
     )
   }

--- a/packages/router.plugins.init/test.ts
+++ b/packages/router.plugins.init/test.ts
@@ -1,6 +1,5 @@
 /* tslint:disable max-classes-per-file */
 
-import { DataModelConstructorBuilder } from '@profiscience/knockout-contrib-model-builders-data'
 import {
   Context,
   Route,


### PR DESCRIPTION
Automatically call viewModel `init` method _after_ declarative initializers have completed. If
promise is returned, will wait for completion before yielding.

BREAKING CHANGE: Potentially breaking. If you already have an init method being called manually, it
will be called twice. Remove your invocation or rename the method.